### PR TITLE
Add email and internet tools

### DIFF
--- a/src/agent_tools.py
+++ b/src/agent_tools.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+from typing import List
+from langchain.tools import tool
+import objects as G
+
+class Toolset:
+    def __init__(self, world: G._WorldState, tick_provider):
+        self.world = world
+        self.tick = tick_provider
+
+    # ---- Email ----
+    @tool("send_email")
+    def send_email(self, sender_type: str, sender_id: int, to_people: List[int] | None = None, to_companies: List[int] | None = None, subject: str = "", body: str = "") -> str:
+        """Send an email to specific recipients."""
+        msg = G.EmailMessage(
+            sender_type=sender_type,
+            sender_id=sender_id,
+            to_people=to_people or [],
+            to_companies=to_companies or [],
+            subject=subject,
+            body=body,
+            timestamp=self.tick(),
+        )
+        self.world.emails.append(msg)
+        return f"sent:{msg.message_id}"
+
+    @tool("inbox")
+    def inbox(self, person_id: int | None = None, company_id: int | None = None) -> str:
+        """List email subjects for the given actor."""
+        msgs = []
+        for m in self.world.emails:
+            if person_id is not None and person_id in m.to_people:
+                msgs.append(f"{m.message_id}:{m.subject}")
+            if company_id is not None and company_id in m.to_companies:
+                msgs.append(f"{m.message_id}:{m.subject}")
+        return "\n".join(msgs)
+
+    @tool("read_email")
+    def read_email(self, email_id: int) -> str:
+        """Read an email by id."""
+        for m in self.world.emails:
+            if m.message_id == email_id:
+                return f"From {m.sender_type} {m.sender_id}: {m.subject}\n{m.body}"
+        return "not found"
+
+    @tool("search_inbox")
+    def search_inbox(self, query: str, person_id: int | None = None, company_id: int | None = None) -> str:
+        """Search email subjects/bodies containing the query for the actor."""
+        q = query.lower()
+        matches = []
+        for m in self.world.emails:
+            if person_id is not None and person_id not in m.to_people:
+                continue
+            if company_id is not None and company_id not in m.to_companies:
+                continue
+            if q in m.subject.lower() or q in m.body.lower():
+                matches.append(f"{m.message_id}:{m.subject}")
+        return "\n".join(matches)
+
+    # ---- Internet ----
+    @tool("write_domain")
+    def write_domain(self, domain: str, path: str, content: str) -> str:
+        """Write content to a domain path."""
+        key = f"{domain}/{path}" if path else domain
+        self.world.internet[key] = content
+        return "ok"
+
+    @tool("read_domain")
+    def read_domain(self, domain: str, path: str = "") -> str:
+        """Read content from a domain path."""
+        key = f"{domain}/{path}" if path else domain
+        return self.world.internet.get(key, "")
+
+    @tool("search_internet")
+    def search_internet(self, query: str) -> str:
+        """Return domain paths containing the query."""
+        q = query.lower()
+        res = [k for k,v in self.world.internet.items() if q in v.lower()]
+        return "\n".join(res)
+
+    def as_tools(self):
+        return [
+            self.send_email,
+            self.inbox,
+            self.read_email,
+            self.search_inbox,
+            self.write_domain,
+            self.read_domain,
+            self.search_internet,
+        ]

--- a/src/llm_agents.py
+++ b/src/llm_agents.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import os
+from typing import List
+
+from langchain.agents import AgentType, initialize_agent
+from langchain_community.chat_models import ChatOpenAI
+from langchain.schema import SystemMessage, HumanMessage
+from agent_tools import Toolset
+
+import objects as G
+
+
+class DummyLLM:
+    """Fallback LLM that returns a constant response."""
+
+    def invoke(self, messages):
+        return type("Dummy", (), {"content": "noop"})()
+
+
+class BaseAgent:
+    def __init__(self, temperature: float = 0.3):
+        api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            self.llm = ChatOpenAI(temperature=temperature, openai_api_key=api_key)
+        else:
+            self.llm = DummyLLM()
+
+    def run(self, messages: List[str]) -> str:
+        chat_messages = [SystemMessage(content=messages[0])] + [HumanMessage(content=m) for m in messages[1:]]
+        result = self.llm.invoke(chat_messages)
+        return getattr(result, "content", "noop")
+
+
+class PersonAgent(BaseAgent):
+    def act(self, person: G._PersonInstance, world: G._WorldState, tick: int) -> str:
+        traits = []
+        for tid in person.personality_traits:
+            trait = world.registry.get("PersonalityTrait", {}).get(tid)
+            if trait:
+                traits.append(f"- {trait.id}: {trait.description}")
+        system = "You control a person in a business simulation. Use the tools to act."
+        short_mem = "\n".join(person.memory.short_term)
+        long_mem = person.memory.long_term.get("general", "")
+        tools = Toolset(world, lambda: tick)
+        if isinstance(self.llm, DummyLLM):
+            return "noop"
+        agent = initialize_agent(tools.as_tools(), self.llm, agent=AgentType.OPENAI_FUNCTIONS, verbose=False)
+        prompt = f"Traits:\n" + "\n".join(traits) + f"\nRecent:\n{short_mem}\nLong:\n{long_mem}"
+        return agent.run(prompt)
+
+
+class CompanyAgent(BaseAgent):
+    def act(self, company: G._CompanyInstance, world: G._WorldState, tick: int) -> str:
+        system = "You control a company in a business simulation. Use the tools to act."
+        tools = Toolset(world, lambda: tick)
+        if isinstance(self.llm, DummyLLM):
+            return "noop"
+        agent = initialize_agent(tools.as_tools(), self.llm, agent=AgentType.OPENAI_FUNCTIONS, verbose=False)
+        prompt = f"Resources: {company.resources}"
+        return agent.run(prompt)

--- a/src/objects.py
+++ b/src/objects.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 from enum import Enum
 from typing import Dict, List, Literal, Optional, Tuple
 from pydantic import BaseModel, Field, PositiveInt, field_validator, model_validator, root_validator, validator, PositiveFloat
+
+MAX_MANAGED_WORKERS = 8
 import itertools
 _id_counter = itertools.count()
 
@@ -253,7 +255,7 @@ class _MachineInstance(BaseModel):
     
     inventory: _Inventory
 
-    @model_validator(pre=True)
+    @model_validator(mode="before")
     def init_inventory(cls, values):
         machine_def = values.get('machine')
         cap = machine_def.inventory_capacity or 0
@@ -421,7 +423,7 @@ class VehicleDefinition(BaseModel):
     fuel_capacity: Decimal = Field(..., description="How many units of fuel it can hold")
     cargo_inventory_size: Decimal
 
-    @validator("max_speed", "fuel_consumption", "fuel_capacity", "stored_resources", pre=True)
+    @validator("max_speed", "fuel_consumption", "fuel_capacity", pre=True)
     def to_decimal(cls, v):
         return Decimal(str(v))
 
@@ -441,7 +443,7 @@ class _VehicleInstance(BaseModel):
     inventory: _Inventory
     fuel_stored: Decimal
 
-    @model_validator(pre=True)
+    @model_validator(mode="before")
     def init_inventory(cls, values):
         vehicle_def: VehicleDefinition = values.get('vehicle_type')
         cap = vehicle_def.cargo_inventory_size or 0
@@ -468,6 +470,7 @@ class _FinancialEntityInstance(BaseModel):
 
 class _CompanyInstance(_FinancialEntityInstance):
     techs: List[str]
+    domain: Optional[str] = None
 
 # Simple resource‑conversion recipe (updated to reference machine *IDs*)
 class ResourceConversion(BaseModel):
@@ -487,68 +490,35 @@ class ResourceConversion(BaseModel):
 # Individuals
 # ────────────────────────────────────────────────────────────────────────────
 
-class _Personality(BaseModel):
-    """
-    Vaguely follows the HEXACO personality traits.
-    """
-    openness: float # openness to new experience- imaginative/philosophical vs. uncreative/unintellectual
-    conscientiousness: float # efficient/organized vs. haphazrd/careless
-    extraversion: float # bold/energetic vs. shy/bashful
-    agreeableness: float # sympathetic/cooperative vs. cold/competitive
-    emotionality: float # moody/nervous vs. relaxed/calm
-    honesty: float # honest, loyal, modest vs. deceitful, greedy, pretentious
-    
-    @classmethod
-    def random(cls):
-        """Return a randomly generated `_Personality` instance.
+class PersonalityTrait(BaseModel):
+    """Static personality trait definition for LLM prompts."""
+    id: str
+    description: str
+    coincidence: Dict[str, float] = Field(default_factory=dict)
 
-        Each trait is drawn from a *trait‑specific Gaussian Mixture Model* (GMM)
-        followed by `np.tanh` to squash the real‑valued draw into (‑1, 1).
-        The GMM parameters were chosen to echo patterns seen in large public
-        HEXACO datasets: some traits skew high, others are more balanced, and
-        emotionality skews low.  All implementation logic lives inside this
-        single method so the class stays self‑contained.
-        """
-        import numpy as np  # local import keeps method standalone
 
-        # (mean, std, weight) tuples for each trait
-        mixtures = {
-            "openness": [ 
-                (1.0, 0.5, 0.65), # high‑creativity majority
-                (-0.5, 0.4, 0.35) # low-creativity minority
-            ],  
-            "conscientiousness": [
-                (1.2, 0.4, 0.70), 
-                (-0.3, 0.6, 0.30)
-            ],
-            "extraversion": [
-                (0.8, 0.6, 0.45),  # outgoing
-                (0.0, 0.4, 0.35),  # ambivert
-                (-0.8, 0.6, 0.20),  # introvert
-            ],
-            "agreeableness": [
-                (0.8, 0.6, 0.35),  # highly cooperative
-                (0.0, 0.4, 0.45),  # average
-                (-0.8, 0.6, 0.20),  # competitive
-            ],
-            "emotionality": [
-                (-1.0, 0.5, 0.55),  # calm majority
-                (0.3, 0.6, 0.45),   # more anxious minority
-            ],
-            "honesty": [
-                (1.1, 0.4, 0.60), 
-                (-0.2, 0.7, 0.40)
-            ],
-        }
+class PersonMemory(BaseModel):
+    """Short and long term memory for individuals."""
+    short_term: List[str] = Field(default_factory=list)
+    long_term: Dict[str, str] = Field(default_factory=dict)
 
-        sampled = {}
-        for trait, comps in mixtures.items():
-            mus, sigmas, weights = zip(*comps)
-            idx = np.random.choice(len(comps), p=weights)
-            raw_value = np.random.normal(mus[idx], sigmas[idx])
-            sampled[trait] = float(np.tanh(raw_value))
+    def add_short(self, entry: str) -> None:
+        self.short_term.append(entry)
+        if len(self.short_term) > 30:
+            self.short_term.pop(0)
 
-        return cls(**sampled)
+
+class EmailMessage(BaseModel):
+    """Simple email object for inter-agent communication."""
+
+    message_id: int = Field(default_factory=get_instance_id)
+    sender_type: Literal["person", "company"]
+    sender_id: int
+    to_people: List[int] = Field(default_factory=list)
+    to_companies: List[int] = Field(default_factory=list)
+    subject: str
+    body: str
+    timestamp: int
 
 class EducationCategory(BaseModel):
     id: str
@@ -584,15 +554,18 @@ class EducationCategory(BaseModel):
         return None
     
 class _PersonInstance(_FinancialEntityInstance):
-    personality: _Personality = _Personality.random()
+    personality_traits: List[str] = Field(default_factory=list)
+    memory: PersonMemory = Field(default_factory=PersonMemory)
     education: Optional[EducationCategory]
+
+    domain: Optional[str] = None
     
     employer_id: Optional[int]
     works_at: Optional[int]
     
     inventory: _Inventory
 
-    @model_validator(pre=True)
+    @model_validator(mode="before")
     def init_inventory(cls, values):
         cap = 5
         values['inventory'] = _Inventory(capacity=cap)
@@ -604,5 +577,8 @@ class _WorldState(BaseModel):
     companies: Dict[int, _CompanyInstance] = Field(default_factory=dict)
     population: Dict[int, _PersonInstance] = Field(default_factory=dict)
     vehicles: Dict[int, _VehicleInstance] = Field(default_factory=dict)
+    registry: Dict[str, dict] = Field(default_factory=dict)
+    emails: List[EmailMessage] = Field(default_factory=list)
+    internet: Dict[str, str] = Field(default_factory=dict)
 
     # ── Helper methods -----------------------------------------------------


### PR DESCRIPTION
## Summary
- implement EmailMessage and world registries for emails and internet
- add domain field to company and person instances
- introduce agent Toolset with email and internet tools
- use Toolset in person and company LLM agents

## Testing
- `python src/sim.py 1`

------
https://chatgpt.com/codex/tasks/task_e_68448df90b24832d8c6d0717a39f6fe2